### PR TITLE
Revise tech stack ADRs for Bun incompatibility

### DIFF
--- a/doc/adr/0004-runtime-and-package-management.md
+++ b/doc/adr/0004-runtime-and-package-management.md
@@ -1,6 +1,6 @@
 # 4. Runtime and Package Management
 
-Date: 2025-06-13 (amended 2025-06-14)
+Date: 2025-06-13 (amended 2025-06-20)
 
 ## Status
 
@@ -8,14 +8,14 @@ Accepted
 
 ## Context
 
-We need to select a JavaScript runtime, version manager and package manager for our React / TypeScript application. The solution should align with our project priorities of minimizing development effort while providing learning opportunities.
+We need to select a JavaScript runtime, version manager and package manager for our React / TypeScript application. The solution should align with our project priorities of minimizing development effort while providing learning opportunities, including keeping abreast of emerging industry trends.
 
 ## Decision
 
 We will use:
 - **Node.js** as our JavaScript runtime
 - **Volta** as our Node.js version manager  
-- **Yarn** as our package manager
+- **Yarn** (Plug'n'Play mode) as our package manager
 
 ### Alternatives Considered
 
@@ -24,33 +24,42 @@ We will use:
 - **Deno** - Rejected as it requires different patterns and has smaller ecosystem
 
 **Version Manager:**
-- **fnm** - Rejected as it requires manual version switching
-- **pnpm** - Rejected as it mixes version and package management concerns
+- **fnm** - Rejected as it requires manual shell configuration for automatic switching
+- **pnpm** - Rejected as its version management capabilities are less mature than dedicated tools
 - **nvm** - Rejected due to slower performance and manual configuration requirements
 - **asdf** - Rejected as universal version management is overkill for Node.js-only project
 
 **Package Manager:**
-- **npm** - Rejected due to slower installation performance
-- **Bun** - Rejected to reduce tooling complexity and focus on established workflows
-- **pnpm** - Rejected due to symlink complexity that could cause CI/CD and cross-platform issues
+- **npm** - Rejected due to slower installation performance and higher disk usage
+- **Yarn Classic** - Rejected in favor of modern Yarn PnP for better performance and dependency management
+- **pnpm** - Strong contender but Yarn PnP offers equivalent performance with better ecosystem compatibility
+- **Bun** - Rejected to maintain Node.js runtime consistency and reduce tooling complexity
 
 ### Key Factors
 
-Runtime consistency between development and production was critical for avoiding deployment issues. Automatic version switching and reliable CI/CD compatibility were prioritized to minimize development overhead.
+1. **Runtime consistency**: Node.js provides universal compatibility and matches production deployment environments
+2. **Zero-configuration team setup**: Volta automatically manages Node.js versions per project without requiring individual developer shell configuration
+3. **Modern package management**: Yarn PnP offers performance comparable to pnpm while maintaining superior IDE and tooling compatibility
+4. **Industry alignment**: Following established tools with strong momentum rather than experimental integrations
+5. **Learning opportunity**: Understanding Yarn PnP's advanced dependency resolution while staying within proven ecosystem boundaries
 
 ## Consequences
 
 **What becomes easier:**
 - Consistent runtime environment from development to production
 - Zero-config team environment consistency via Volta
-- Faster package installation with Yarn compared to npm
+- Significantly faster package installation and reduced disk usage
 - Automatic Node.js version switching per project
-- Reliable CI/CD compatibility without symlink complexity
+- Strict dependency isolation prevents phantom dependency issues
+- Better monorepo support for potential future scaling
+- Shared package installations across multiple projects
 
 **What becomes more difficult:**
 - Learning Volta instead of more common nvm workflow
-- Additional tool beyond standard npm
+- Understanding Yarn PnP's loader-based architecture vs traditional node_modules
+- Potential IDE configuration for optimal PnP support
 
 **Risks:**
 - Volta is newer with smaller ecosystem than nvm
-- Fallback to established tools (nvm + npm) is straightforward if needed
+- Yarn PnP may require workarounds for some tools
+- Fallback to traditional tools (nvm + npm) is straightforward if needed

--- a/doc/adr/0004-runtime-and-package-management.md
+++ b/doc/adr/0004-runtime-and-package-management.md
@@ -1,6 +1,6 @@
 # 4. Runtime and Package Management
 
-Date: 2025-06-18
+Date: 2025-06-13 (amended 2025-06-14)
 
 ## Status
 
@@ -12,44 +12,45 @@ We need to select a JavaScript runtime, version manager and package manager for 
 
 ## Decision
 
-We will use **Bun** as both our JavaScript runtime and package manager.
+We will use:
+- **Node.js** as our JavaScript runtime
+- **Volta** as our Node.js version manager  
+- **Yarn** as our package manager
 
 ### Alternatives Considered
 
-**Runtime + Package Manager:**
-- **Node.js + npm** - Rejected due to slower performance and separate tooling complexity
-- **Node.js + Yarn** - Rejected in favor of unified toolchain approach
-- **Node.js + pnpm** - Rejected in favor of unified toolchain approach
+**Runtime:**
+- **Bun runtime** - Rejected due to SSR compatibility issues with React Router v7 framework mode
 - **Deno** - Rejected as it requires different patterns and has smaller ecosystem
 
-**Version Management:**
-- Not needed with Bun as it includes built-in version management
-- **Volta** - Would be redundant with Bun's unified approach
-- **nvm/fnm** - Would be redundant with Bun's approach
+**Version Manager:**
+- **fnm** - Rejected as it requires manual version switching
+- **pnpm** - Rejected as it mixes version and package management concerns
+- **nvm** - Rejected due to slower performance and manual configuration requirements
+- **asdf** - Rejected as universal version management is overkill for Node.js-only project
+
+**Package Manager:**
+- **npm** - Rejected due to slower installation performance
+- **Bun** - Rejected to reduce tooling complexity and focus on established workflows
+- **pnpm** - Rejected due to symlink complexity that could cause CI/CD and cross-platform issues
 
 ### Key Factors
 
-- **Unified toolchain**: Single tool for runtime, package management, and TypeScript execution
-- **Performance**: Faster package installation and application startup
-- **Simplified development**: Built-in TypeScript support eliminates build steps
-- **Forward-thinking**: Learning experience with next-generation JavaScript runtime
-- **Reduced complexity**: Eliminates need for separate version and package managers
+Runtime consistency between development and production was critical for avoiding deployment issues. Automatic version switching and reliable CI/CD compatibility were prioritized to minimize development overhead.
 
 ## Consequences
 
 **What becomes easier:**
-- Zero-config TypeScript execution without build steps
-- Faster package installation compared to npm/yarn
-- Simplified toolchain with fewer moving parts
-- Consistent development and production environments via Docker
-- No need for separate version management tools
+- Consistent runtime environment from development to production
+- Zero-config team environment consistency via Volta
+- Faster package installation with Yarn compared to npm
+- Automatic Node.js version switching per project
+- Reliable CI/CD compatibility without symlink complexity
 
 **What becomes more difficult:**
-- Smaller ecosystem with potential package compatibility issues
-- Less community support and fewer Stack Overflow answers
-- Debugging tools and workflows less mature than Node.js
+- Learning Volta instead of more common nvm workflow
+- Additional tool beyond standard npm
 
 **Risks:**
-- Ecosystem compatibility gaps for some npm packages
-- Dependency on relatively new technology with smaller community
-- Potential migration complexity if switching back to Node.js becomes necessary
+- Volta is newer with smaller ecosystem than nvm
+- Fallback to established tools (nvm + npm) is straightforward if needed

--- a/doc/adr/0007-testing-and-ci-cd-strategy.md
+++ b/doc/adr/0007-testing-and-ci-cd-strategy.md
@@ -15,7 +15,7 @@ As a single-developer hobby project focused on learning TypeScript and modern we
 We will implement the following development toolchain:
 
 ### Testing
-- **Bun's built-in test runner** + **React Testing Library** for unit and component testing
+- **Vitest** + **React Testing Library** for unit and component testing
 - **Playwright** for potential future E2E testing (when needed)
 
 ### Code Quality
@@ -30,8 +30,7 @@ We will implement the following development toolchain:
 ### Alternatives Considered
 
 **Testing Frameworks:**
-- **Vitest** - Rejected in favor of Bun's built-in test runner for unified toolchain
-- **Jest** - Rejected due to additional configuration overhead
+- **Jest** - Rejected in favor of Vitest due to better Vite integration and faster performance
 - **Cypress** - Rejected for E2E in favor of Playwright's better TypeScript support
 
 **Code Quality Tools:**
@@ -42,21 +41,20 @@ We will implement the following development toolchain:
 - **Husky + lint-staged** - Rejected due to multiple dependencies and JavaScript-based configuration
 - **Simple Git Hooks** - Rejected due to manual setup requirements
 
-
 ### Key Decision Factors
 
 Choices prioritized:
 1. **Minimal configuration**: Tools that work with sane defaults
 2. **Single-tool solutions**: Biome over ESLint+Prettier, Lefthook over Husky+lint-staged
 3. **Learning-friendly**: Strong TypeScript integration and helpful error messages
-4. **Integration**: Compatibility with React Router v7, Vite bundler, and Bun runtime
+4. **Integration**: Compatibility with React Router v7, Vite, and Docker deployment
 
 ## Consequences
 
 **What becomes easier:**
 - Zero-config code quality enforcement with Biome's defaults
 - Consistent development environment across different machines with Lefthook
-- Unified testing workflow with Bun's built-in test runner eliminating separate framework configuration
+- Fast test feedback with Vitest's integration with our Vite-based stack
 - TypeScript learning with strict mode preventing bad habits
 
 **What becomes more difficult:**

--- a/doc/adr/0007-testing-and-ci-cd-strategy.md
+++ b/doc/adr/0007-testing-and-ci-cd-strategy.md
@@ -1,6 +1,6 @@
 # 7. Testing and CI/CD Strategy
 
-Date: 2025-06-18
+Date: 2025-06-18 (amended 2025-06-20)
 
 ## Status
 
@@ -21,7 +21,7 @@ We will implement the following development toolchain:
 ### Code Quality
 - **Biome** for both linting and formatting
 - **TypeScript strict mode** for enhanced type safety
-- **Lefthook** for git hook management
+- **Husky + git-format-staged** for git hook management
 
 ### CI/CD
 - **GitHub Actions** for continuous integration
@@ -38,31 +38,31 @@ We will implement the following development toolchain:
 - **dprint** - Rejected due to smaller community and less integration with VS Code
 
 **Git Hook Managers:**
-- **Husky + lint-staged** - Rejected due to multiple dependencies and JavaScript-based configuration
-- **Simple Git Hooks** - Rejected due to manual setup requirements
+- **Lefthook** - Rejected due to suboptimal handling of mixed staged/unstaged changes
+- **Husky + lint-staged** - Rejected due to multiple dependencies (~1500) and similar staging limitations
+- **pre-commit** - Rejected due to unnecessary complexity for single-project use
 
 ### Key Decision Factors
 
 Choices prioritized:
 1. **Minimal configuration**: Tools that work with sane defaults
-2. **Single-tool solutions**: Biome over ESLint+Prettier, Lefthook over Husky+lint-staged
-3. **Learning-friendly**: Strong TypeScript integration and helpful error messages
+2. **Single-tool solutions**: Biome over ESLint+Prettier
+3. **Workflow compatibility**: Support for partial staging (common when splitting commits logically)
 4. **Integration**: Compatibility with React Router v7, Vite, and Docker deployment
 
 ## Consequences
 
 **What becomes easier:**
 - Zero-config code quality enforcement with Biome's defaults
-- Consistent development environment across different machines with Lefthook
+- Precise control over what gets committed when using partial staging with git-format-staged
 - Fast test feedback with Vitest's integration with our Vite-based stack
 - TypeScript learning with strict mode preventing bad habits
 
 **What becomes more difficult:**
 - Less flexibility for highly customized linting rules compared to ESLint
-- Smaller community for Biome/Lefthook troubleshooting compared to traditional tools
-- Learning new tool-specific configurations instead of industry-standard ones
+- Smaller community for Biome troubleshooting compared to traditional tools
 
 **Risks:**
 - Biome is newer and may have fewer edge-case solutions than ESLint
-- Dependency on newer tools with potentially less stability
+- git-format-staged has smaller community than lint-staged for troubleshooting
 - Migration complexity if switching back to traditional toolchain later


### PR DESCRIPTION
## Background

During initial app setup, we encountered a critical runtime error when starting the React Router v7 application with Bun:

```
$ bun --bun react-router-serve ./build/server/index.js
1 | (function (entry, fetcher)
              ^
SyntaxError: Export named 'renderToPipeableStream' not found in module '/app/node_modules/react-dom/server.bun.js'.
      at requestImportModule (1:11)

Bun v1.2.16 (Linux arm64)
error: "react-router-serve" exited with code 1
error: script "start" exited with code 1
```

This error is due to Bun being incompatible with React Router / Remix. Research revealed that [Bun has known SSR compatibility issues with Remix](https://bun.sh/guides/ecosystem/remix) (and therefore React Router v7 in framework mode), making it unsuitable for our chosen framework stack.

Switching away from Bun had knock-on effects on other tech stack decisions, requiring updates to package management, testing frameworks, and development tooling choices.

🤖 Generated with [Claude Code](https://claude.ai/code)

-----

I also happened to notice, while researching the above, that [git-format-staged](https://github.com/hallettj/git-format-staged) is particularly well suited to my personal workflow style, so I switched from Lefthook to that too. — @jadatkins