### PR TITLE
feat(hooks): run 'pnpm install' on checkout, merge, and rebase

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Only act on branch checkouts (arg $3 is 1), not file checkouts (0)
+[ "$3" = '0' ] && exit
+[ "$3" = '1' ] || exit
+
+case "$1" in
+  *[!0]*)
+    # Contains a non-zero character → a real commit
+    OLD_HEAD="$1"
+    ;;
+  *)
+    # All zeros → null ref (fresh clone): treat as an empty repository
+    OLD_HEAD=$(git hash-object -t tree /dev/null)
+    ;;
+esac
+
+bash scripts/sync-deps.sh "$OLD_HEAD" "$2"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,1 @@
+bash scripts/sync-deps.sh ORIG_HEAD HEAD

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,0 +1,1 @@
+bash scripts/sync-deps.sh ORIG_HEAD HEAD

--- a/scripts/sync-deps.sh
+++ b/scripts/sync-deps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Run 'pnpm install' when pnpm-lock.yaml has changed.
+# To be used as a git hook.
+
+set -u
+
+git diff --quiet "$1" "$2" -- pnpm-lock.yaml && exit 0
+
+pnpm install || true


### PR DESCRIPTION
Automatically run `pnpm install` after pulling the latest `main` branch, rebasing, etc.