### PR TITLE
ci: add auto-merge workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+name: Auto Merge Dependabot
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v3
+      - uses: fastify/github-action-merge-dependabot@v3
+        if: ${{ steps.dependabot-metadata.outputs.maintainer-changes == 'false' }}
+        with:
+          target: minor
+          merge-method: squash
+          use-github-auto-merge: true


### PR DESCRIPTION
Automatically merge Dependabot PRs (after tests pass) using fastify's [Github Action Merge Dependabot](https://github.com/marketplace/actions/github-action-merge-dependabot)

## Security features

- **Commit verification**: `dependabot/fetch-metadata` cryptographically verifies that the PR was opened by Dependabot and that every commit is Dependabot-signed. If any commit fails verification, the workflow fails before the merge step runs.
- **Maintainer change guard**: If Dependabot detects a package maintainer change — a potential supply chain attack vector — the merge step is skipped, leaving the PR open for manual review.

## Configuration

- Merges patch and minor updates (`target: minor`)
- Uses GitHub's native auto-merge feature, so the actual merge only happens once CI passes and branch protection rules are satisfied