### PR TITLE
chore: use local biome schema to avoid version drift

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Avoids warnings like this every time you run lint checks:

<img width="642" height="360" alt="Screenshot 2026-07-15 at 19 19 57" src="https://github.com/user-attachments/assets/c376747a-5f71-4425-9384-6eefaabbd6ee" />

```
pnpm run check
$ biome check --write .
biome.json:2:14 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ℹ The configuration schema version does not match the CLI version 2.5.3

    1 │ {
  > 2 │   "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
      │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 │   "vcs": {
    4 │     "enabled": true,

  ℹ   Expected:                     2.5.3
      Found:                        2.5.2


  ℹ Run the command biome migrate to migrate the configuration file.


Checked 23 files in 26ms. No fixes applied.
Found 1 info.
```